### PR TITLE
Modify some hyperparameters

### DIFF
--- a/curl_sac.py
+++ b/curl_sac.py
@@ -67,6 +67,7 @@ class Actor(nn.Module):
             nn.Linear(hidden_dim, hidden_dim), nn.ReLU(),
             nn.Linear(hidden_dim, 2 * action_shape[0])
         )
+        self.test_layer = nn.Linear(17, 17)
 
         self.outputs = dict()
         self.apply(weight_init)
@@ -87,7 +88,8 @@ class Actor(nn.Module):
         encode_obs = self.encoder(image_obs, detach=detach_encoder)
 
         #print('shapes of obs after reshape:', obs.shape, ": ", encode_obs.shape)
-        combine_obs = torch.cat((obs,encode_obs),axis = -1)
+        modified_obs = torch.sigmoid(self.test_layer(obs))
+        combine_obs = torch.cat((modified_obs,encode_obs),axis = -1)
 
         mu, log_std = self.trunk(combine_obs).chunk(2, dim=-1)
 


### PR DESCRIPTION
Modified Actor
reward: 367
| eval | S: 90000 | ER: 338.0780
| train | E: 0 | S: 90000 | D: 15.5 s | R: 0.0000 | BR: 0.0000 | A_LOSS: 0.0000 | CR_LOSS: 0.0000 | CU_LOSS: 0.0000
| train | E: 721 | S: 90500 | D: 11.1 s | R: 330.9588 | BR: 2.4496 | A_LOSS: -214.0621 | CR_LOSS: 1.8410 | CU_LOSS: 0.0130
| train | E: 725 | S: 91000 | D: 11.2 s | R: 358.4814 | BR: 2.4326 | A_LOSS: -214.2717 | CR_LOSS: 1.6868 | CU_LOSS: 0.0144
| train | E: 729 | S: 91500 | D: 11.1 s | R: 331.5757 | BR: 2.4730 | A_LOSS: -214.7664 | CR_LOSS: 1.6355 | CU_LOSS: 0.0137
| train | E: 733 | S: 92000 | D: 11.3 s | R: 320.2591 | BR: 2.4621 | A_LOSS: -215.1322 | CR_LOSS: 3.5097 | CU_LOSS: 0.0163
| train | E: 737 | S: 92500 | D: 11.2 s | R: 333.3439 | BR: 2.4789 | A_LOSS: -216.1279 | CR_LOSS: 1.6498 | CU_LOSS: 0.0095
| train | E: 741 | S: 93000 | D: 11.1 s | R: 338.8353 | BR: 2.3908 | A_LOSS: -216.5571 | CR_LOSS: 1.5856 | CU_LOSS: 0.0360
| train | E: 745 | S: 93500 | D: 11.1 s | R: 356.4167 | BR: 2.4577 | A_LOSS: -217.2492 | CR_LOSS: 1.5375 | CU_LOSS: 0.0146
| train | E: 749 | S: 94000 | D: 11.2 s | R: 342.1000 | BR: 2.4452 | A_LOSS: -217.8356 | CR_LOSS: 1.6380 | CU_LOSS: 0.0113
| train | E: 753 | S: 94500 | D: 11.2 s | R: 359.1542 | BR: 2.4657 | A_LOSS: -218.4188 | CR_LOSS: 1.4046 | CU_LOSS: 0.0089
| train | E: 757 | S: 95000 | D: 11.2 s | R: 325.8494 | BR: 2.4295 | A_LOSS: -219.2256 | CR_LOSS: 1.5521 | CU_LOSS: 0.0119
| train | E: 761 | S: 95500 | D: 11.0 s | R: 309.1551 | BR: 2.4475 | A_LOSS: -219.5115 | CR_LOSS: 1.7139 | CU_LOSS: 0.0105
| train | E: 765 | S: 96000 | D: 11.1 s | R: 320.3039 | BR: 2.4988 | A_LOSS: -220.2170 | CR_LOSS: 1.4699 | CU_LOSS: 0.0177
| train | E: 769 | S: 96500 | D: 11.0 s | R: 322.0220 | BR: 2.4581 | A_LOSS: -221.2698 | CR_LOSS: 1.4768 | CU_LOSS: 0.0235
| train | E: 773 | S: 97000 | D: 11.1 s | R: 325.9357 | BR: 2.4566 | A_LOSS: -221.9028 | CR_LOSS: 1.4258 | CU_LOSS: 0.0196
| train | E: 777 | S: 97500 | D: 11.1 s | R: 366.3562 | BR: 2.4512 | A_LOSS: -222.2585 | CR_LOSS: 1.4370 | CU_LOSS: 0.0234
| train | E: 781 | S: 98000 | D: 11.3 s | R: 330.8986 | BR: 2.4758 | A_LOSS: -223.1650 | CR_LOSS: 1.3694 | CU_LOSS: 0.0145
| train | E: 785 | S: 98500 | D: 11.2 s | R: 322.5803 | BR: 2.4893 | A_LOSS: -224.2745 | CR_LOSS: 1.3811 | CU_LOSS: 0.0287
| train | E: 789 | S: 99000 | D: 11.2 s | R: 332.5384 | BR: 2.4565 | A_LOSS: -224.6835 | CR_LOSS: 1.6567 | CU_LOSS: 0.0204
| train | E: 793 | S: 99500 | D: 11.3 s | R: 343.9800 | BR: 2.4614 | A_LOSS: -225.2752 | CR_LOSS: 1.3651 | CU_LOSS: 0.0250
| train | E: 797 | S: 100000 | D: 0.0 s | R: 328.8037 | BR: 2.5043 | A_LOSS: -225.1784 | CR_LOSS: 1.7272 | CU_LOSS: 0.0150
| eval | S: 100000 | ER: 367.1833